### PR TITLE
Keep sending 'snap' after snaping on line

### DIFF
--- a/leaflet.snap.js
+++ b/leaflet.snap.js
@@ -189,11 +189,8 @@ L.Snap.updateSnap = function (marker, layer, latlng) {
             if (marker._icon) {
                 L.DomUtil.addClass(marker._icon, 'marker-snapped');
             }
-            marker.fire('snap', {layer:layer, latlng: latlng});
         }
-        else {
-            marker.fire('snap', {layer:layer, latlng: latlng});
-        }
+        marker.fire('snap', {layer:layer, latlng: latlng});
     }
     else {
         if (marker.snap) {

--- a/leaflet.snap.js
+++ b/leaflet.snap.js
@@ -191,6 +191,9 @@ L.Snap.updateSnap = function (marker, layer, latlng) {
             }
             marker.fire('snap', {layer:layer, latlng: latlng});
         }
+        else {
+            marker.fire('snap', {layer:layer, latlng: latlng});
+        }
     }
     else {
         if (marker.snap) {


### PR DESCRIPTION
This changement are created for prevent the snapping of one topology on the closest point and not on the marker. 
It was difficult to put a topology in a multiple path and make this topology linked to all this paths. 
